### PR TITLE
Remove streams executable from tests

### DIFF
--- a/test/jbuild
+++ b/test/jbuild
@@ -6,11 +6,6 @@
    (preprocess (pps (ppx_stage.ppx)))))
 
 (executable
-  ((name streams)
-   (modules (streams stream_shape))
-   (preprocess (pps (ppx_stage.ppx)))))
-
-(executable
   ((name strymonas_example)
    (modules (strymonas strymonas_example))
    (preprocess (pps (ppx_stage.ppx)))))


### PR DESCRIPTION
Currently `opam pin` fails with the following error: `No implementation for module Streams in _build/default/test`. 

Maybe you forgot to add/commit the `streams.ml` and `stream_shape.ml` files? If not this PR removes the target so that the project can be pinned without errors.

PS: This is the most exciting syntax extension I've seen for OCaml, thank you!