### PR TITLE
Upgrade from ocaml-migrate-parsetree to Ppxlib

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 2.0)
+(lang dune 3.1)
 (name ppx_stage)

--- a/ppx/binding.ml
+++ b/ppx/binding.ml
@@ -1,9 +1,5 @@
-open Migrate_parsetree
-open Ast_408
-
-open Asttypes
-open Parsetree
-open Ast_helper
+open Ppxlib
+open Ppxlib.Ast_builder.Default
 
 type binding_site = Binder of int | Context of int
 
@@ -30,7 +26,7 @@ and analyse_exp_desc env loc = function
        | PStr [ {pstr_desc=Pstr_eval (e, _); _} ] ->
           e
        | _ ->
-          raise (Location.(Error (error ~loc ("[%e] expects an expression")))) in
+         raise (Location.(Error (Error.make ~sub:[] ~loc ("[%e] expects an expression")))) in
      let h = env.fresh_hole () in
      Hashtbl.add env.hole_table h (env.bindings, code);
      Pexp_ident { txt = Lident ("," ^ string_of_int h); loc }
@@ -95,9 +91,8 @@ and analyse_exp_desc env loc = function
      let env' = analyse_pat env pat in
      Pexp_for (pat, analyse_exp env e1, analyse_exp env e2, dir, analyse_exp env' body)
   (* several missing... *)
-       
 
-  | _ -> raise (Location.(Error (error ~loc ("expression not supported in staged code"))))
+  | _ -> raise (Location.(Error (Error.make ~sub:[] ~loc ("expression not supported in staged code"))))
 
 and analyse_exp_opt env = function
   | None -> None
@@ -109,7 +104,7 @@ and analyse_pat env pat =
 
 and analyse_pat_desc env loc = function
   | Ppat_any -> env
-  | Ppat_var v -> analyse_pat_desc env loc (Ppat_alias (Pat.any (), v))
+  | Ppat_var v -> analyse_pat_desc env loc (Ppat_alias (ppat_any ~loc, v))
   | Ppat_alias (pat, v) ->
      let env = analyse_pat env pat in
      { env with bindings = IdentMap.add v.txt (env.fresh_binder ()) env.bindings }
@@ -117,8 +112,8 @@ and analyse_pat_desc env loc = function
   | Ppat_interval _ -> env
   | Ppat_tuple pats -> List.fold_left analyse_pat env pats
   | Ppat_construct (_loc, None) -> env
-  | Ppat_construct (_loc, Some pat) -> analyse_pat env pat
-  | _ -> raise (Location.(Error (error ~loc ("pattern not supported in staged code"))))
+  | Ppat_construct (_loc, Some (_locs, pat)) -> analyse_pat env pat
+  | _ -> raise (Location.(Error (Error.make ~sub:[] ~loc ("pattern not supported in staged code"))))
 
 and analyse_case env {pc_lhs; pc_guard; pc_rhs} =
   let env' = analyse_pat env pc_lhs in
@@ -131,7 +126,7 @@ and analyse_attributes = function
 | {attr_payload=PStr []; _} :: rest ->
    analyse_attributes rest
 | {attr_name={loc;txt}; _} :: _ ->
-   raise (Location.(Error (error ~loc ("attribute " ^ txt ^ " not supported in staged code"))))
+    raise (Location.(Error (Error.make ~sub:[] ~loc ("attribute " ^ txt ^ " not supported in staged code"))))
 
 
 let analyse_binders (context : int IdentMap.t) (e : expression) :
@@ -150,94 +145,4 @@ let analyse_binders (context : int IdentMap.t) (e : expression) :
   e', hole_table
 
 
-
-open Ast_mapper
-type substitutable =
-| SubstContext of int
-| SubstHole of int
-
-let substitute_holes (e : expression) (f : substitutable -> expression) =
-  let expr mapper pexp =
-    match pexp.pexp_desc with
-    | Pexp_ident { txt = Lident v; loc = _ } ->
-       let id () = int_of_string (String.sub v 1 (String.length v - 1)) in
-       (match v.[0] with
-       | ',' -> f (SubstHole (id ()))
-       | ';' -> f (SubstContext (id ()))
-       | _ -> pexp)
-    | _ -> default_mapper.expr mapper pexp in
-  let mapper = { default_mapper with expr } in
-  mapper.expr mapper e
-
-
-let module_remapper f =
-  let rename (id : Longident.t Location.loc) : Longident.t Location.loc =
-    let rec go : Longident.t -> Longident.t = function
-      | Lident id -> Lident (f id)
-      | Ldot (id, x) -> Ldot (go id, x)
-      | Lapply (idF, idX) -> Lapply (go idF, go idX) in
-    {id with txt = go id.txt} in
-  let open Parsetree in
-  let open Ast_mapper in
-  let rec expr mapper pexp =
-    let pexp_desc = match pexp.pexp_desc with
-      | Pexp_ident id ->
-         Pexp_ident (rename id)
-      | Pexp_construct (id, e) ->
-         Pexp_construct (rename id, expr_opt mapper e)
-      | Pexp_record (fs, e) ->
-         let fs = List.map (fun (id, e) -> (rename id, expr mapper e)) fs in
-         Pexp_record (fs, expr_opt mapper e)
-      | Pexp_field (e, f) ->
-         Pexp_field (expr mapper e, rename f)
-      | Pexp_setfield (e, f, x) ->
-         Pexp_setfield (expr mapper e, rename f, expr mapper x)
-      | Pexp_new id ->
-         Pexp_new (rename id)
-      | Pexp_open (md, e) ->
-         Pexp_open ({md with popen_expr = module_expr mapper md.popen_expr },
-                    expr mapper e)
-      | _ -> (default_mapper.expr mapper pexp).pexp_desc in
-    { pexp with pexp_desc }
-  and expr_opt mapper = function
-    | None -> None
-    | Some e -> Some (expr mapper e)
-  and typ mapper ptyp =
-    let ptyp_desc = match ptyp.ptyp_desc with
-      | Ptyp_constr (id, tys) ->
-         Ptyp_constr (rename id, List.map (typ mapper) tys)
-      | Ptyp_class (id, tys) ->
-         Ptyp_class (rename id, List.map (typ mapper) tys)
-      | _ -> (default_mapper.typ mapper ptyp).ptyp_desc in
-    { ptyp with ptyp_desc }
-  and pat mapper ppat =
-    let ppat_desc = match ppat.ppat_desc with
-      | Ppat_construct (id, pat) ->
-         Ppat_construct (rename id, pat_opt mapper pat)
-      | Ppat_record (fs, flag) ->
-         let fs = List.map (fun (id, p) -> (rename id, pat mapper p)) fs in
-         Ppat_record (fs, flag)
-      | Ppat_type id ->
-         Ppat_type (rename id)
-      | Ppat_open (id, p) ->
-         Ppat_open (rename id, pat mapper p)
-      | _ -> (default_mapper.pat mapper ppat).ppat_desc in
-    { ppat with ppat_desc }
-  and pat_opt mapper = function
-    | None -> None
-    | Some p -> Some (pat mapper p)
-  and module_type mapper pmty =
-    let pmty_desc = match pmty.pmty_desc with
-      | Pmty_ident id -> Pmty_ident (rename id)
-      | Pmty_alias id -> Pmty_alias (rename id)
-      | _ -> (default_mapper.module_type mapper pmty).pmty_desc in
-    { pmty with pmty_desc }
-  and open_description _mapper op =
-    { op with popen_expr = rename op.popen_expr }
-  and module_expr mapper pmod =
-    let pmod_desc = match pmod.pmod_desc with
-      | Pmod_ident id -> Pmod_ident (rename id)
-      | _ -> (default_mapper.module_expr mapper pmod).pmod_desc in
-    { pmod with pmod_desc }
-  in
-  { default_mapper with expr; typ; pat; module_type; open_description; module_expr }
+let module_remapper = Ppx_stage.Internal.module_remapper

--- a/ppx/dune
+++ b/ppx/dune
@@ -3,6 +3,5 @@
  (public_name ppx_stage.ppx)
  (kind ppx_rewriter)
  (ppx_runtime_libraries ppx_stage.runtime-lib)
- (preprocess
-  (pps ppx_tools_versioned.metaquot_408))
- (libraries ocaml-migrate-parsetree ppx_tools_versioned ppx_stage.runtime-lib))
+ (preprocess (pps ppxlib.metaquot))
+ (libraries ppx_stage.runtime-lib ppxlib))

--- a/ppx_stage.opam
+++ b/ppx_stage.opam
@@ -10,6 +10,5 @@ build:
 available: [ ocaml-version >= "4.08" ]
 depends: [
   "dune" {build & >= "2.0"}
-  "ocaml-migrate-parsetree"
-  "ppx_tools_versioned"
+  "ppxlib"
 ]

--- a/runtime/dune
+++ b/runtime/dune
@@ -1,9 +1,4 @@
 (library
  (name ppx_stage)
  (public_name ppx_stage.runtime-lib)
- (libraries compiler-libs.common))
-
-(rule
- (targets compat.ml)
- (deps compat.cppo.ml)
- (action (run %{bin:cppo} %{deps} -V OCAML:%{ocaml_version} -o %{targets})))
+ (libraries ppxlib ppxlib.ast))

--- a/runtime/ppx_stage.ml
+++ b/runtime/ppx_stage.ml
@@ -3,7 +3,7 @@ module IdentMap = IdentMap
 
 type 'a code = {
   compute : Internal.Environ.t -> 'a;
-  source : Internal.Renaming.t -> Internal.dynamic_modcontext -> Parsetree.expression;
+  source : Internal.Renaming.t -> Internal.dynamic_modcontext -> Ppxlib.expression;
 }
 
 let to_parsetree_structure f =
@@ -15,34 +15,34 @@ let to_parsetree_structure f =
 let run f = f.compute Internal.Environ.empty
 
 let print ppf f =
-  Pprintast.structure ppf (to_parsetree_structure f)
+  Astlib.Pprintast.structure ppf (to_parsetree_structure f)
 
 
 
 module Lift = struct
-  open Parsetree
-  open Ast_helper
+  open Ppxlib
+  open Ppxlib.Ast_builder.Default
 
   let lift c p = { compute = (fun _env -> c); source = (fun _ren _modst -> p) }
 
   let int x : int code =
-    lift x (Exp.constant (Pconst_integer (string_of_int x, None)))
+    lift x (eint ~loc:Location.none x)
   let int32 x : Int32.t code =
-    lift x (Exp.constant (Pconst_integer (Int32.to_string x, Some 'l')))
+    lift x (eint32 ~loc:Location.none x)
   let int64 x : Int64.t code =
-    lift x (Exp.constant (Pconst_integer (Int64.to_string x, Some 'L')))
+    lift x (eint64 ~loc:Location.none x)
   let bool x : bool code =
-    lift x (Exp.construct (Location.mknoloc (Longident.Lident (string_of_bool x))) None)
+    lift x (ebool ~loc:Location.none x)
   let float x : float code =
     (* OCaml's string_of_float is a bit broken *)
     let s = string_of_float x in
     if float_of_string s = x then
-      lift x (Exp.constant (Pconst_float (s, None)))
+      lift x (efloat ~loc:Location.none s)
     else
-      lift x (Exp.constant (Pconst_float (Printf.sprintf "%h" x, None)))
+      lift x (efloat ~loc:Location.none (Printf.sprintf "%h" x))
   let string x : string code =
-    lift x (Exp.constant (Compat.pconst_string x))
+    lift x (estring ~loc:Location.none x)
 end
 
 
-type staged_module = Parsetree.module_expr
+type staged_module = Ppxlib.Parsetree.module_expr

--- a/test/dune
+++ b/test/dune
@@ -10,6 +10,7 @@
 (executable
  (name mod)
  (modules mod)
+ (flags (:standard -warn-error -A))
  (preprocess
   (pps ppx_stage.ppx)))
 

--- a/test/example.ml
+++ b/test/example.ml
@@ -1,3 +1,5 @@
+[@@@warning "-32"]
+
 let () = Format.printf "STARTUP@."
 let unit = [%code ()]
 let two = [%code [%e Format.printf "EARLY@."; unit]; 2]


### PR DESCRIPTION
ocaml-migrate-parsetree is now deprecated. This upgrades the code to use Ppxlib, so that ppx_stage can be used on recent OCaml versions.

With these changes, the code now compiles and passes the tests in OCaml 5.1.1.

Future work: handle locations correctly so that tools like Merlin are not buggy on code that uses the PPX.